### PR TITLE
Fix for bug that caused exotic timestamps to appear in backend

### DIFF
--- a/Sources/Flightdeck/EventModel.swift
+++ b/Sources/Flightdeck/EventModel.swift
@@ -10,6 +10,7 @@ import Foundation
 struct Event: Codable {
     let clientType, clientConfig, clientVersion, event, datetimeUTC: String
     var datetimeLocal, timezone, language, properties, appVersion, appInstallDate, osName, osVersion, deviceManufacturer, deviceModel: String?
+    var debug: Bool = false
     var firstOfSession, firstOfHour, firstOfDay, firstOfWeek, firstOfMonth, firstOfQuarter: Bool?
     var previousEvent, previousEventDatetimeUTC: String?
 
@@ -27,6 +28,7 @@ struct Event: Codable {
         case osVersion = "os_version"
         case deviceManufacturer = "device_manufacturer"
         case deviceModel = "device_model"
+        case debug = "debug"
         case firstOfSession = "first_of_session"
         case firstOfHour = "first_of_hour"
         case firstOfDay = "first_of_day"
@@ -35,13 +37,5 @@ struct Event: Codable {
         case firstOfQuarter = "first_of_quarter"
         case previousEvent = "previous_event"
         case previousEventDatetimeUTC = "previous_event_datetime_utc"
-    }
-    
-    init(clientType: String, clientVersion: String, clientConfig: String, event: String, datetimeUTC: String) {
-        self.clientType = clientType
-        self.clientVersion = clientVersion
-        self.clientConfig = clientConfig
-        self.event = event
-        self.datetimeUTC = datetimeUTC
     }
 }

--- a/Sources/Flightdeck/Flightdeck.swift
+++ b/Sources/Flightdeck/Flightdeck.swift
@@ -329,6 +329,7 @@ public class Flightdeck {
         let dateNow = Date()
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.calendar = Calendar(identifier: .iso8601)
 
         dateFormatter.timeZone = TimeZone.current
         let datetimeLocal = dateFormatter.string(from: dateNow)


### PR DESCRIPTION
Updated scope. This PR contains:
- Fix for inconsistent y-m-d values due to different calendars. Enforcing one single calendar standard now
- Adding `debug` properties to event metadata
- Version bump to `1.1.0`